### PR TITLE
New*er* built-ins

### DIFF
--- a/src/japt-0.2.js
+++ b/src/japt-0.2.js
@@ -115,11 +115,8 @@ Number.prototype.w = function(x){return Math.max(this,x)}
 // Shorter Math Properties
 Math.t = Math.atan2;
 Math.f = Math.factorial;
-/* Fibbonacci*/ Math.F = function F (n) { return n <= 1 ? n : Math.F(n-1) + Math.F(n-2); };
-/* Math.r = */ Object.defineProperty(Math, 'r', {get:function(){return Math.random()},configurable:true}); // Math.r is a getter so we don't need ()
-
-Math.P = Math.PI;
-
+Math.g = function g (n) { return n <= 1 ? n : Math.g(n-1) + Math.g(n-2); };
+Math.r = Math.random;
 Math.p = function(n, prime) { // Prime Factorization, if 2nd arg is trusey, will return if num is prime
     var r, f = [], x, d = 1 < n;
     while( d ){ r = Math.sqrt(n); x = 2;
@@ -128,6 +125,8 @@ Math.p = function(n, prime) { // Prime Factorization, if 2nd arg is trusey, will
     }
     return prime ? f.length === 1 : f;
 }
+
+Math.P = Math.PI;
 
 void(0); // Completely optional
 

--- a/src/japt-interpreter.js
+++ b/src/japt-interpreter.js
@@ -41,10 +41,10 @@ String.prototype.k = function(x){return this.replace(RegExp(x),"")}
 String.prototype.l = function(){return this.length}
 String.prototype.m = function(x){return this.split('').map(x).join('')}
 String.prototype.n = function(x){return parseInt(this,x||10)}
-String.prototype.o = function(){noFunc('So')}
+String.prototype.o = function(x){return this.replace(new RegExp('[^'+x+']','gi'),"")} // Removes all but specified characters. Similar to TeaScript's O function
 String.prototype.p = function(x){return this.repeat(x)}
 String.prototype.q = function(x){return this.split(x)}
-String.prototype.r = function(x,y){return this.replace(RegExp(x,"g"),y)}
+String.prototype.r = function(x,y,z){return this.replace(RegExp(x,(z||"")+"g"),y)}
 String.prototype.s = function(x,y){if(typeof(y)==="undefined")y=this.length;if(y<0)y+=this.length;return this.substring(x,y)}
 String.prototype.t = function(x,y){if(typeof(y)==="undefined")y=this.length;return this.substr(x,y)}
 String.prototype.u = function(){return this.toUpperCase()}
@@ -117,6 +117,19 @@ Math.r = Math.random;
 Math.P = Math.PI;
 
 void(0); // Completely optional
+
+// String compression
+// Be sure to make sure shoco is loaded. 
+// JS File - http://ed-von-schleck.github.io/shoco/shoco.js
+
+/*
+shoco.c = function (str) { return Array.prototype.map.call(shoco.compress(str), function (char) { return String.fromCharCode(char) }).join('') };
+
+shoco.d = function (str) { return shoco.decompress(new Uint8Array( ( str.constructor == Array ? str[0] : str ).split('').map(function (char) {
+        return char.charCodeAt(0) }))) };
+        
+window.L = shoco; // You can change L to any variable you want
+*/
 
 function clear_output() {
     document.getElementById("output").value = "";
@@ -202,17 +215,20 @@ function evalInput(input) {
   return processed;
 }
 
-function shorthand (code) {
+// Call this function with a second argument. If second arg is trusey
+function shorthand (code, autogolf) {
     // 0xA1 (161) is the first printable non-ASCII, so we'll start from there
     var pairs = {
         // Using \u<hex> to avoid encoding incompatibilities
         // Feel free to change these
         "\u00A1": "Um@", // ¡ - 161
         "\u00A2": "Us2", // ¢ - 162
+        "\u00A3": "m@",  // £ - 163
+        "\u00A4": "=="   // ¤ - 164
     };
     
     return Object.keys(pairs).reduce(function (code, char) {
-        return code.replace(new RegExp(char, 'g'), pairs[ char ]);
+        return code.replace(new RegExp(autogolf ? pairs[char] : char, 'g'), autogolf ? char : pairs[ char ]);
     }, code);
 }
 

--- a/src/japt-interpreter.js
+++ b/src/japt-interpreter.js
@@ -25,7 +25,7 @@ var defFuncs = {
   u: "while(!",
   v: "evalJapt(",
   w: "while("};
-  
+
 String.prototype.repeat = String.prototype.repeat||function(x){if(x<0)return'';for(var y='',i=x|0;i--;)y+=this;return y}
 String.prototype.a = function(){return this.split('');}
 String.prototype.b = function(x){return this.indexOf(x)}
@@ -50,7 +50,7 @@ String.prototype.t = function(x,y){if(typeof(y)==="undefined")y=this.length;retu
 String.prototype.u = function(){return this.toUpperCase()}
 String.prototype.v = function(){return this.toLowerCase()}
 String.prototype.w = function(){return this.split('').reverse().join('')}
-  
+
 Array.prototype.a = function(){return this.join('');}
 Array.prototype.b = function(x){return this.indexOf(x)}
 Array.prototype.c = function(x){return this.lastIndexOf(x)}
@@ -127,30 +127,30 @@ shoco.c = function (str) { return Array.prototype.map.call(shoco.compress(str), 
 
 shoco.d = function (str) { return shoco.decompress(new Uint8Array( ( str.constructor == Array ? str[0] : str ).split('').map(function (char) {
         return char.charCodeAt(0) }))) };
-        
+
 window.L = shoco; // You can change L to any variable you want
 */
 
 function clear_output() {
-    document.getElementById("output").value = "";
-    document.getElementById("stderr").innerHTML = "";
+  document.getElementById("output").value = "";
+  document.getElementById("stderr").innerHTML = "";
 }
 
 function stop() {
-    running = false;
-    document.getElementById("run").disabled = false;
-    document.getElementById("stop").disabled = true;
-    document.getElementById("clear").disabled = false;
-    document.getElementById("timeout").disabled = false;
+  running = false;
+  document.getElementById("run").disabled = false;
+  document.getElementById("stop").disabled = true;
+  document.getElementById("clear").disabled = false;
+  document.getElementById("timeout").disabled = false;
 }
 
 function interrupt() {
-    error(ERROR_INTERRUPT);
+  error(ERROR_INTERRUPT);
 }
 
 function error(msg) {
-    document.getElementById("stderr").innerHTML = msg;
-    stop();
+  document.getElementById("stderr").innerHTML = msg;
+  stop();
 }
 
 function evalInput(input) {
@@ -217,34 +217,34 @@ function evalInput(input) {
 
 // Call this function with a second argument. If second arg is trusey
 function shorthand (code, autogolf) {
-    // 0xA1 (161) is the first printable non-ASCII, so we'll start from there
-    var pairs = {
-        // Using \u<hex> to avoid encoding incompatibilities
-        // Feel free to change these
-        "\u00A1": "Um@", // ¡ - 161
-        "\u00A2": "Us2", // ¢ - 162
-        "\u00A3": "m@",  // £ - 163
-        "\u00A4": "=="   // ¤ - 164
-    };
-    
-    return Object.keys(pairs).reduce(function (code, char) {
-        return code.replace(new RegExp(autogolf ? pairs[char] : char, 'g'), autogolf ? char : pairs[ char ]);
-    }, code);
+  // 0xA1 (161) is the first printable non-ASCII, so we'll start from there
+  var pairs = {
+    // Using \u<hex> to avoid encoding incompatibilities
+    // Feel free to change these
+    "\u00A1": "Um@", // ¡ - 161
+    "\u00A2": "Us2", // ¢ - 162
+    "\u00A3": "m@",  // £ - 163
+    "\u00A4": "=="   // ¤ - 164
+  };
+
+  return Object.keys(pairs).reduce(function (code, char) {
+    return code.replace(new RegExp(autogolf ? pairs[char] : char, 'g'), autogolf ? char : pairs[ char ]);
+  }, code);
 }
 
 function run() {
-    clear_output();
-    document.getElementById("run").disabled = true;
-    document.getElementById("stop").disabled = false;
-    document.getElementById("clear").disabled = true;
-    document.getElementById("input").disabled = false;
-    document.getElementById("timeout").disabled = false;
-    
-    code = document.getElementById("code").value;
-    input = document.getElementById("input").value;
-    timeout = document.getElementById("timeout").checked;
-  
-    A = 10,
+  clear_output();
+  document.getElementById("run").disabled = true;
+  document.getElementById("stop").disabled = false;
+  document.getElementById("clear").disabled = true;
+  document.getElementById("input").disabled = false;
+  document.getElementById("timeout").disabled = false;
+
+  code = document.getElementById("code").value;
+  input = document.getElementById("input").value;
+  timeout = document.getElementById("timeout").checked;
+
+  A = 10,
     B = 11,
     C = 12,
     D = 13,
@@ -270,15 +270,15 @@ function run() {
     X = N[3],
     Y = N[4],
     Z = N[5];
-    
-    if (!safe_unicode) code = shorthand(code) || "";
-    evalJapt(code);
-  
-    document.getElementById("run").disabled = false;
-    document.getElementById("stop").disabled = true;
-    document.getElementById("clear").disabled = false;
-    document.getElementById("input").disabled = false;
-    document.getElementById("timeout").disabled = false;
+
+  if (!safe_unicode) code = shorthand(code) || "";
+  evalJapt(code);
+
+  document.getElementById("run").disabled = false;
+  document.getElementById("stop").disabled = true;
+  document.getElementById("clear").disabled = false;
+  document.getElementById("input").disabled = false;
+  document.getElementById("timeout").disabled = false;
 }
 
 function subparen(code) {
@@ -331,28 +331,28 @@ function fixParens(code) {
 }
 
 function evalJapt(code) {
-    var codes = [], strings = [], i = 0, j = 0;
-    
-    code = code
-      .replace(/"[^"]*("|.$)/g,function(x){strings[i]=x+(x.slice(-1)=="\""?"":"\"");return"\""+i+++"\""})
-      .replace(/\$([^\$]*)\$/g,function(x,y){codes[i]=y;return"$"+i+++"$"})
-      .replace(/'./g,function(x){strings[i]=x+"'";return"\""+i+++"\""})
-      .replace(/#./g,function(x){return x.charCodeAt(1)})
-      .replace(/\)/g,"))")
-      .replace(/ /g,")")
-      .replace(/@/g,"(X,Y,Z)=>")
-      .replace(/(.)([a-w])/g,function(x,y,z){return y+(/[0-9]/.test(y)?' .':'.')+z+'('});
-    code = fixParens(code);
-    code = code
-      .replace(/\$(\d+)\$/g,function(_,x){return codes[x]})
-      .replace(/(\??)"(\d+)"/g,function(_,y,x){return y+strings[x].replace(/([^\\]):/,function(x,z){return y=="?"?z+"\":\"":x}).replace(/([^\\]){([^}]+)}/g,"$1\"+($2)+\"")});
-    
-    alert("JS code: "+code);
-    try {
-      var result=eval(code);
-      alert("Result: "+result);
-      document.getElementById("output").value = result;
-    } catch (e) {
-      alert(e);
-    }
+  var codes = [], strings = [], i = 0, j = 0;
+
+  code = code
+    .replace(/"[^"]*("|.$)/g,function(x){strings[i]=x+(x.slice(-1)=="\""?"":"\"");return"\""+i+++"\""})
+    .replace(/\$([^\$]*)\$/g,function(x,y){codes[i]=y;return"$"+i+++"$"})
+    .replace(/'./g,function(x){strings[i]=x+"'";return"\""+i+++"\""})
+    .replace(/#./g,function(x){return x.charCodeAt(1)})
+    .replace(/\)/g,"))")
+    .replace(/ /g,")")
+    .replace(/@/g,"(X,Y,Z)=>")
+    .replace(/(.)([a-w])/g,function(x,y,z){return y+(/[0-9]/.test(y)?' .':'.')+z+'('});
+  code = fixParens(code);
+  code = code
+    .replace(/\$(\d+)\$/g,function(_,x){return codes[x]})
+    .replace(/(\??)"(\d+)"/g,function(_,y,x){return y+strings[x].replace(/([^\\]):/,function(x,z){return y=="?"?z+"\":\"":x}).replace(/([^\\]){([^}]+)}/g,"$1\"+($2)+\"")});
+
+  alert("JS code: "+code);
+  try {
+    var result=eval(code);
+    alert("Result: "+result);
+    document.getElementById("output").value = result;
+  } catch (e) {
+    alert(e);
+  }
 }

--- a/src/japt-interpreter.js
+++ b/src/japt-interpreter.js
@@ -31,7 +31,7 @@ String.prototype.a = function(){return this.split('');}
 String.prototype.b = function(x){return this.indexOf(x)}
 String.prototype.c = function(x){return this.charCodeAt(x)}
 String.prototype.d = function(){noFunc('Sd')}
-String.prototype.e = function(){noFunc('Se')}
+String.prototype.e = function(x,y,z){var t=this.replace(x instanceof RegExp?x:RegExp(x,z||"g"),y||"");return t===this?this:this.e(x,y,z)} // "Recursive" replaces
 String.prototype.f = function(){noFunc('Sf')}
 String.prototype.g = function(x){return this.charAt(x)}
 String.prototype.h = function(x,y){return this.substring(0,x)+y+this.substring(x+y.length)}
@@ -75,7 +75,7 @@ Array.prototype.u = function(){noFunc('Au')}
 Array.prototype.v = function(){noFunc('Av')}
 Array.prototype.w = function(){return this.reverse()}
 
-Number.prototype.a = function(){noFunc('Na')}
+Number.prototype.a = function(){return Math.abs(this)}
 Number.prototype.b = function(x,y){return this<x?x:this>y?y:this}
 Number.prototype.c = function(){return Math.ceil(this)}
 Number.prototype.d = function(){return String.fromCharCode(this)}
@@ -86,7 +86,7 @@ Number.prototype.h = function(){noFunc('Nh')}
 Number.prototype.i = function(){noFunc('Ni')}
 Number.prototype.j = function(){noFunc('Nj')}
 Number.prototype.k = function(){noFunc('Nk')}
-Number.prototype.l = function(){noFunc('Nl')}
+Number.prototype.l = function(x){return Math.factorial(this);}
 Number.prototype.m = function(x){return Math.min(this,x)}
 Number.prototype.n = function(){return-this}
 Number.prototype.o = function(x,y){

--- a/src/japt-interpreter.js
+++ b/src/japt-interpreter.js
@@ -37,7 +37,7 @@ String.prototype.g = function(x){return this.charAt(x)}
 String.prototype.h = function(x,y){return this.substring(0,x)+y+this.substring(x+y.length)}
 String.prototype.i = function(x,y){return this.substring(0,x)+y+this.substring(x)}
 String.prototype.j = function(x,y){if(typeof(y)==="undefined")y=1;return this.substring(0,x)+this.substring(x+y)}
-String.prototype.k = function(x){return this.replace(RegExp(x),"")}
+String.prototype.k = function(x,y){return this.replace(RegExp(x,y),"")}
 String.prototype.l = function(){return this.length}
 String.prototype.m = function(x,y){return this.split(y||'').map(x).join(y||'')}
 String.prototype.n = function(x){return parseInt(this,x||10)}
@@ -68,11 +68,11 @@ Array.prototype.n = function(x){return this.sort(x)}
 Array.prototype.o = function(){return this.pop()}
 Array.prototype.p = function(x){return this.push(x)}
 Array.prototype.q = function(x){return this.join(x)}
-Array.prototype.r = function(x){return this.reduce(x)}
+Array.prototype.r = function(x,y){return this.reduce(x,y)}
 Array.prototype.s = function(x,y){if(typeof(y)==="undefined")y=this.length;return this.slice(x,y)}
 Array.prototype.t = function(x,y){if(typeof(y)==="undefined")y=this.length;return this.slice(x,x+y)}
-Array.prototype.u = function(){noFunc('Au')}
-Array.prototype.v = function(){noFunc('Av')}
+Array.prototype.u = function(x){return this.unshift(x)}
+Array.prototype.v = function(){return this.shift()}
 Array.prototype.w = function(){return this.reverse()}
 
 Number.prototype.a = function(){return Math.abs(this)}

--- a/src/japt-interpreter.js
+++ b/src/japt-interpreter.js
@@ -39,7 +39,7 @@ String.prototype.i = function(x,y){return this.substring(0,x)+y+this.substring(x
 String.prototype.j = function(x,y){if(typeof(y)==="undefined")y=1;return this.substring(0,x)+this.substring(x+y)}
 String.prototype.k = function(x){return this.replace(RegExp(x),"")}
 String.prototype.l = function(){return this.length}
-String.prototype.m = function(x){return this.split('').map(x).join('')}
+String.prototype.m = function(x,y){return this.split(y||'').map(x).join(y||'')}
 String.prototype.n = function(x){return parseInt(this,x||10)}
 String.prototype.o = function(x){return this.replace(new RegExp('[^'+x+']','gi'),"")} // Removes all but specified characters. Similar to TeaScript's O function
 String.prototype.p = function(x){return this.repeat(x)}

--- a/src/japt-interpreter.js
+++ b/src/japt-interpreter.js
@@ -113,7 +113,19 @@ Number.prototype.v = function(){return this%2===0?1:0}
 Number.prototype.w = function(x){return Math.max(this,x)}
 
 // Shorter Math Properties
+Math.t = Math.atan2;
+Math.f = Math.factorial;
+Math.g = function g (n) { return n <= 1 ? n : Math.g(n-1) + Math.g(n-2); };
 Math.r = Math.random;
+Math.p = function(n, prime) { // Prime Factorization, if 2nd arg is trusey, will return if num is prime
+    var r, f = [], x, d = 1 < n;
+    while( d ){ r = Math.sqrt(n); x = 2;
+        if (n % x) { x = 3; while ((n % x) && ((x += 2) < r)); }
+        f.push(x = x > r ? n : x); d = ( x != n ); n /= x;
+    }
+    return prime ? f.length === 1 : f;
+}
+
 Math.P = Math.PI;
 
 void(0); // Completely optional


### PR DESCRIPTION
In these commits I've added a few things that I think will help Japt.

---
## Autogolfing

Now, the `shorthand()` function when provided with a second argument, will auto-golf the code.
You can call this and it will return the auto-golfed code.

Call it without the second argument and the code will be un-auto-golfed

---
## [String compression](https://github.com/ETHproductions/Japt/pull/4/files#diff-d37029f134ae829dd65c2c2a4f786eadR133)

I've currently [commented](https://github.com/ETHproductions/Japt/pull/4/files#diff-d37029f134ae829dd65c2c2a4f786eadR137) this code out as you'll need to include the shoco library (more info in the code).

This adds two functions. [`shoco.c`](https://github.com/ETHproductions/Japt/pull/4/files#diff-d37029f134ae829dd65c2c2a4f786eadR138) for compression, and [`shoco.d`](https://github.com/ETHproductions/Japt/pull/4/files#diff-d37029f134ae829dd65c2c2a4f786eadR140) for decompression. 

TeaScript uses `L` to reference shoco but that's currently in use so I've left it up to you to decide where you'd like to go with that

---
## Function changes
I've made _slight_ changes to a few functions.

 - `String.prototype.m` accepts a second argument, this means `qS m@<code> qS` can become `m@<code>,S`.

 - `String.prototype.k` accepts flags as a second argument.

 - `Array.prototype.r` accepts a second reduce argument as reduce functions often use them.

---
## New functions

I've added a few new functions.

 - `String.prototype.e` are the recursive replaces

 - `Number.prototype.a` runs `Math.abs`

 - `Number.prototype.l` runs `Math.factorial`

 - `Math.g` is fibonacci

 - `Math.p` is prime factorization

 - `Array.prototype.u` runs `[].unshift(x)`

 - `Array.prototype.v` runs `[].shift()`

---
## New shortened property names
I've shortened a few property names:

 - `Math.t` => `Math.atan2`
 - `Math.f` => `Math.factorial`

---
## New unicode shortcuts
I've added a few new unicode shortcuts

 - `£` (0xA3 163) => `m@`
 - `¤` (0xA4 164) => `==`

---

Thanks, Vihan