### PR TITLE
Polyglot builtins!

### DIFF
--- a/src/japt-interpreter.js
+++ b/src/japt-interpreter.js
@@ -516,6 +516,8 @@ function transpile(code) {
 	// Some helpful functions
 	function isChar (str, char) { return RegExp('^['+char+']$').test(str); }
 
+    var polyglot = '"(p|';
+  
 	for (i = 0; i < code.length; i++) {
 		var char = code[i];
 		if (char === ";" && i === 0) { outp += "newvars()"; }
@@ -528,7 +530,10 @@ function transpile(code) {
 		else if (isChar(outp.slice(-1),"*%") && isChar(char," \\)\\]};"))
 			code = code.slice(0,i)+'2'+code.slice(i);
 		
-		if (isChar(char, "`\"")) { // If new token is a quotation mark " or backtick `
+		if (code.slice(i).indexOf(polyglot) === 0) {
+          outp = code.slice(i + polyglot.length).split('"')[0];
+          i = code.length;
+        } else if (isChar(char, "`\"")) { // If new token is a quotation mark " or backtick `
 			var qm = outp.slice(-1) === "?"; // Question Mark
 			var str = "";
 			for (i++; code[i] !== char && i < code.length; i++) {


### PR DESCRIPTION
I've implemented something similar into TeaScript. Essentially when this exact sequence of code is found:
```
"(p|
```
everything until the next `"` (or end) will be what's compiled.

---

Example:
```
"(p|123
```

will become: `123`

---

How is this helpful? Example:
```
"[p|`Hello, World!`";"(p|`Hello, World`";print"Hello, World!"
```

This is now a Japt, TeaScript, and Python polyglot. (First part is TeaScript, then Japt, then Python)