### PR TITLE
Fixed Number.k() bug

### DIFF
--- a/src/japt-interpreter.js
+++ b/src/japt-interpreter.js
@@ -237,7 +237,7 @@ df(Number,'g',function(){return this.toString()=="NaN"?"NaN":this<0?-1:this>0?1:
 df(Number,'h',function(x){x=fb(x,1);return this.toPrecision(x)});
 df(Number,'i',function(x){return Japt.intervals[Japt.intervals.length]=setInterval(x,this)});
 df(Number,'j',function(){var n=+this;if(n===2)return true;if(n%1||n<2||n%2===0)return false;for(var i=3,s=Math.sqrt(n);i<=s;i+=2)if(n%i===0)return false;return true});
-df(Number,'k',function(){var n=this,r,f=[],x,d=1<n;while(d){r=Math.sqrt(n);x=2;if(n%x){x=3;while(n%x&&((x+=2)<r));}f.push(x=x>r?n:x);d=(x!=n);n/=x;}return f});
+df(Number,'k',function(){var n=+this,r,f=[],x,d=1<n;while(d){r=Math.sqrt(n);x=2;if(n%x){x=3;while(n%x&&((x+=2)<r));}f.push(x=x>r?n:x);d=(x!=n);n/=x;}return f});
 df(Number,'l',function(){var n=Math.trunc(this),x=Math.trunc(this);if(n<1)return 1;while(--n)x*=n;return x});
 df(Number,'m',function(){return[].reduce.call(arguments,function(x,y){return Math.min(x,y)},this)});
 df(Number,'n',function(x){x=fb(x,0);return x-this});


### PR DESCRIPTION
When the result of `Number.k()` was a one-item array, that one item was a `Number` object instead of an ordinary number. This breaks code that checks for an item's existence in the array. For example, `2k ø2`, which checks if the number `2` exists in the array of factors of `2`, returns false when it should return true.

Example in Chrome dev console
![Example](http://i.imgur.com/4NawhOk.png)

This was fixed similarly to how I see you handling some other Number functions: by casting the Number object to an ordinary number by using `+this`.

[1]:http://ethproductions.github.io/japt/?v=1.4.5&code=Mmsg+DI=&input=