### PR TITLE
Add argument to N.d()

### DIFF
--- a/docs/master.html
+++ b/docs/master.html
@@ -483,8 +483,8 @@
 <p>Returns `this` bounded with min `n₁` and max `n₂`.</p>
 <h3>`.c(n=1)`</h3>
 <p>Returns `this` rounded up to the nearest multiple of `n`.</p>
-<h3>`.d()`</h3>
-<p>Returns the char at code-point `this`.</p>
+<h3>`.d(n=0)`</h3>
+<p>Returns the char at code-point `this+n`.</p>
 <h3>`.e(n)`</h3>
 <p>Returns `this*Math.pow(10,n)`.</p>
 <h3>`.f(n=1)`</h3>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"> 
 <title>Japt interpreter</title>
-<link rel="stylesheet" type="text/css" href="https://ethproductions.github.io/style/style.css">
+<link rel="stylesheet" type="text/css" href="../style/style.css">
 <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
 <link href='https://fonts.googleapis.com/css?family=Inconsolata:400,700' rel='stylesheet' type='text/css'>
 </head>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"> 
 <title>Japt interpreter</title>
-<link rel="stylesheet" type="text/css" href="../style/style.css">
+<link rel="stylesheet" type="text/css" href="https://ethproductions.github.io/style/style.css">
 <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
 <link href='https://fonts.googleapis.com/css?family=Inconsolata:400,700' rel='stylesheet' type='text/css'>
 </head>

--- a/src/japt-interpreter.js
+++ b/src/japt-interpreter.js
@@ -242,7 +242,7 @@ df(Array,'\xFB',function(x,y){return this.pad(x,y,0)});
 df(Number,'a',function(x){x=fb(x,0);return Math.abs(this-x)});
 df(Number,'b',function(x,y){return this<x?x:this>y?y:this});
 df(Number,'c',function(x){x=fb(x,1);return Math.ceil(this/x)*x});
-df(Number,'d',function(){return String.fromCharCode(this)});
+df(Number,'d',function(x){x=fb(x,0);return String.fromCharCode(this+x)});
 df(Number,'e',function(x){return this*Math.pow(10,x)});
 df(Number,'f',function(x){x=fb(x,1);return Math.floor(this/x)*x});
 df(Number,'g',function(){return this.toString()=="NaN"?"NaN":this<0?-1:this>0?1:0});

--- a/src/japt.js
+++ b/src/japt.js
@@ -1288,8 +1288,9 @@ df(Number.prototype, {
 		x = fb(x, 1);
 		return Math.ceil(this / x) * x;
 	},
-	d: function () {
-		return String.fromCharCode(this);
+	d: function (x) {
+		x = fb(x, 0);
+		return String.fromCharCode(this + x);
 	},
 	e: function (x) {
 		return this * Math.pow(10, x);


### PR DESCRIPTION
Hope you don't mind the PR.

I added an argument `n` to `N.d()` which, if provided, will be added to `N` before it's converted to a string. So, instead of `(N+n).d()`, we now have `N.d(n)`.

**Example Usage**
Currently, to generate an array of all ASCII characters, we use `95o_+H d` or `#~õH md`, or a couple of other options. With this change, we can achieve that with `95odH`.