### PR TITLE
Add RegEx Classes for Consonants

### DIFF
--- a/docs/v2.html
+++ b/docs/v2.html
@@ -70,6 +70,8 @@
   <tr><td>\V</td><td>Anything else</td></tr>
   <tr><td>\y</td><td>AEIOUYaeiouy</td></tr>
   <tr><td>\Y</td><td>Anything else</td></tr>
+  <tr><td>\c</td><td>B-DF-HJ-NP-TV-Zb-df-hj-np-tv-z</td></tr>
+  <tr><td>\C</td><td>Anything else</td></tr>
 </table>
 <p>Note: because `/` is parsed as the start of a regex, `÷` is used for division.</p>
 <p>If you have a regex that's just a single class, you can omit the outer slashes. This means that e.g. `/\v/` can be shortened to `\v`. There are a few special shortcuts as well:</p>

--- a/src/japt.js
+++ b/src/japt.js
@@ -71,7 +71,7 @@ function regexify(string, flags) {
 				regex += inCharClass ? "a-z" : "[a-z]";
 			else if (char === "c")
 				regex += inCharClass ? "B-DF-HJ-NP-TV-Zb-df-hj-np-tv-z" : "[B-DF-HJ-NP-TV-Zb-df-hj-np-tv-z]";
-			else if (char === "V")
+			else if (char === "C")
 				regex += inCharClass ? "\\W0-9AaEeIiOoUu_" : "[^B-DF-HJ-NP-TV-Zb-df-hj-np-tv-z]";
 			else if (char === "l")
 				regex += inCharClass ? "A-Za-z" : "[A-Za-z]";

--- a/src/japt.js
+++ b/src/japt.js
@@ -69,6 +69,10 @@ function regexify(string, flags) {
 				regex += inCharClass ? "A-Z" : "[A-Z]";
 			else if (char === "a")
 				regex += inCharClass ? "a-z" : "[a-z]";
+			else if (char === "c")
+				regex += inCharClass ? "B-DF-HJ-NP-TV-Zb-df-hj-np-tv-z" : "[B-DF-HJ-NP-TV-Zb-df-hj-np-tv-z]";
+			else if (char === "V")
+				regex += inCharClass ? "\\W0-9AaEeIiOoUu_" : "[^B-DF-HJ-NP-TV-Zb-df-hj-np-tv-z]";
 			else if (char === "l")
 				regex += inCharClass ? "A-Za-z" : "[A-Za-z]";
 			else if (char === "L")


### PR DESCRIPTION
`\c` matches `[B-DF-HJ-NP-TV-Zb-df-hj-np-tv-z]` and `\C` matches anything else.

Throw an eye over it before merging - currently at 32 hours (and counting) without sleep!